### PR TITLE
bug fix: also count unseen edges when depth == 0

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -198,9 +198,6 @@ void explore(const fen_set_t::EmbeddedSet &fen_list, int depth,
     if (!is_new_entry)
       continue;
 
-    if (depth == 0)
-      continue;
-
     if (fens_with_unseen) {
       int count_unseen = count_unseen_moves(board, result, handle, stats);
       if (count_unseen)
@@ -210,6 +207,9 @@ void explore(const fen_set_t::EmbeddedSet &fen_list, int depth,
               ctor(std::move(key), count_unseen);
             });
     }
+
+    if (depth == 0)
+      continue;
 
     // No moves to explore (can this happen?)
     if (n_elements <= 1)


### PR DESCRIPTION
Fix an oversight that leads to incorrect statistics (the percentage of nodes with unseen edges is underestimated in master).

Master:
```
> ./cdbsubtree --fen startpos --depth 4 --findUnseenEdges --moves
Opening DB
Going through all moves for rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
    a2a3 : 72233 nodes
    b2b3 : 83845 nodes
    c2c3 : 87598 nodes
    d2d3 : 122318 nodes
    e2e3 : 149008 nodes
    f2f3 : 70960 nodes
    g2g3 : 85030 nodes
    h2h3 : 72235 nodes
    a2a4 : 84847 nodes
    b2b4 : 84289 nodes
    c2c4 : 92388 nodes
    d2d4 : 135923 nodes
    e2e4 : 150688 nodes
    f2f4 : 77743 nodes
    g2g4 : 83062 nodes
    h2h4 : 85460 nodes
    b1a3 : 78119 nodes
    b1c3 : 90551 nodes
    g1f3 : 89964 nodes
    g1h3 : 78125 nodes
Closing DB
```

Patch:
```
> ./cdbsubtree --fen startpos --depth 4 --findUnseenEdges --moves
Opening DB
Going through all moves for rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
    a2a3 : 72233 nodes, 7182 (9%) have 11242 unseen edges
    b2b3 : 83845 nodes, 6279 (7%) have 9385 unseen edges
    c2c3 : 87598 nodes, 8035 (9%) have 12269 unseen edges
    d2d3 : 122318 nodes, 9974 (8%) have 15283 unseen edges
    e2e3 : 149008 nodes, 11411 (7%) have 16484 unseen edges
    f2f3 : 70960 nodes, 5856 (8%) have 8880 unseen edges
    g2g3 : 85030 nodes, 7048 (8%) have 10698 unseen edges
    h2h3 : 72235 nodes, 6627 (9%) have 10230 unseen edges
    a2a4 : 84847 nodes, 9305 (10%) have 14821 unseen edges
    b2b4 : 84289 nodes, 8412 (9%) have 13148 unseen edges
    c2c4 : 92388 nodes, 9575 (10%) have 16477 unseen edges
    d2d4 : 135923 nodes, 13452 (9%) have 19854 unseen edges
    e2e4 : 150688 nodes, 12253 (8%) have 18268 unseen edges
    f2f4 : 77743 nodes, 7265 (9%) have 11371 unseen edges
    g2g4 : 83062 nodes, 8247 (9%) have 13287 unseen edges
    h2h4 : 85460 nodes, 8616 (10%) have 13806 unseen edges
    b1a3 : 78119 nodes, 7065 (9%) have 11364 unseen edges
    b1c3 : 90551 nodes, 9067 (10%) have 14479 unseen edges
    g1f3 : 89964 nodes, 8401 (9%) have 13743 unseen edges
    g1h3 : 78125 nodes, 6975 (8%) have 10934 unseen edges
Saved 75431 positions with a total of 116718 unseen edges in unseen.epd.
Closing DB
```

Observe that the number of positions found with unseen edges corresponds 1:1 to the numbers found with `--depth 5` in master, see https://github.com/vondele/cdbsubtree/pull/1#issuecomment-2488794348.